### PR TITLE
Exclude noTier items

### DIFF
--- a/ItemCounters/ItemCountersPlugin.cs
+++ b/ItemCounters/ItemCountersPlugin.cs
@@ -27,8 +27,7 @@ namespace ItemCounters {
                 int tier3Count = master.inventory.GetTotalItemCountOfTier(ItemTier.Tier3);
                 int lunarCount = master.inventory.GetTotalItemCountOfTier(ItemTier.Lunar);
                 int bossCount = master.inventory.GetTotalItemCountOfTier(ItemTier.Boss);
-                int noTierCount = master.inventory.GetTotalItemCountOfTier(ItemTier.NoTier);
-                int totalItemCount = tier1Count + tier2Count + tier3Count + lunarCount + bossCount + noTierCount;
+                int totalItemCount = tier1Count + tier2Count + tier3Count + lunarCount + bossCount;
 
                 StringBuilder sb = new StringBuilder();
                 sb.AppendFormat("<nobr><color=#fff>{0} (", totalItemCount);


### PR DESCRIPTION
Exclude noTier items from the totalItemCount.

NoTier items aren't visible ingame and including them to the total count makes it appear inaccurate (especially when they're no included in the brackets, meaning the sum of the numbers in the brackets doesn't match to total count once player has any items with no tier).